### PR TITLE
Use graphql-js directly without apollo-test-utils

### DIFF
--- a/example/.storybook/config.js
+++ b/example/.storybook/config.js
@@ -6,7 +6,8 @@ import mocks from '../schema/mocks';
 addDecorator(
   apolloStorybookDecorator({
     typeDefs,
-    mocks
+    mocks,
+    context: { value: 'Hello from the resolver context!' }
   })
 );
 

--- a/example/schema/mocks.js
+++ b/example/schema/mocks.js
@@ -23,6 +23,9 @@ export default {
       helloWorld: () => {
         return 'Hello from Apollo!!';
       },
+      helloContext: (root, args, context) => {
+        return context.value;
+      },
       allUsers: () => {
         return new MockList(10);
       },

--- a/example/schema/typeDefinitions.js
+++ b/example/schema/typeDefinitions.js
@@ -14,6 +14,7 @@ export default `
 
   type Query {
     helloWorld: String
+    helloContext: String
     currentUser: User
     counts: Int
   }

--- a/example/stories/index.js
+++ b/example/stories/index.js
@@ -19,6 +19,26 @@ HelloWorld = graphql(
   `,
 )(HelloWorld);
 
+let HelloContext = function HelloContext({ data }) {
+  const hello = data && data.helloContext;
+  if (data && data.loading) {
+    return <h1>Loading one second please!</h1>;
+  }
+  return (
+    <h1>
+      {hello}
+    </h1>
+  );
+};
+
+HelloContext = graphql(
+  gql`
+    query helloContext {
+      helloContext
+    }
+  `
+)(HelloContext);
+
 let CurrentUser = function CurrentUser({ data }) {
   const user = data && data.currentUser;
   if (data && data.loading) {
@@ -77,6 +97,9 @@ Counter = compose(
 storiesOf('Apollo Client', module)
   .add('Hello World Test', () => {
     return <HelloWorld />;
+  })
+  .add('Hello World Test (using the context)', () => {
+    return <HelloContext />;
   })
   .add('Current User', () => {
     return <CurrentUser />;

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "babel-preset-stage-0": "^6.24.1",
     "eslint": "^3.3.1",
     "faker": "^4.1.0",
+    "graphql": "^0.10.5",
     "graphql-tools": "^1.1.0",
     "pre-commit": "^1.2.2",
     "react": "^15.6.1",
@@ -41,7 +42,7 @@
   "peerDependencies": {
     "@storybook/addon-actions": "^3.1.6",
     "apollo-client": "^1.7.0",
-    "apollo-test-utils": "^0.3.2",
+    "graphql": "^0.10.5",
     "graphql-tools": "^1.1.0",
     "react": "^15.6.1",
     "react-apollo": "^1.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,18 +2,7 @@
 # yarn lockfile v1
 
 
-"@storybook/addon-actions@^3.1.6":
-  version "3.1.6"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-actions/-/addon-actions-3.1.6.tgz#0cbf00ede57ff00d1dfe02e554043d6963940064"
-  dependencies:
-    "@storybook/addons" "^3.1.6"
-    deep-equal "^1.0.1"
-    json-stringify-safe "^5.0.1"
-    prop-types "^15.5.8"
-    react-inspector "^2.0.0"
-    uuid "^3.1.0"
-
-"@storybook/addon-actions@^3.1.8":
+"@storybook/addon-actions@^3.1.6", "@storybook/addon-actions@^3.1.8":
   version "3.1.8"
   resolved "https://registry.yarnpkg.com/@storybook/addon-actions/-/addon-actions-3.1.8.tgz#2b6d7aa97530b19965c1010b822f40b130ebbc4d"
   dependencies:
@@ -3009,9 +2998,9 @@ graphql-tools@^1.0.0, graphql-tools@^1.1.0:
   optionalDependencies:
     "@types/graphql" "^0.9.0"
 
-graphql@^0.10.0:
-  version "0.10.3"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-0.10.3.tgz#c313afd5518e673351bee18fb63e2a0e487407ab"
+graphql@^0.10.0, graphql@^0.10.5:
+  version "0.10.5"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-0.10.5.tgz#c9be17ca2bdfdbd134077ffd9bbaa48b8becd298"
   dependencies:
     iterall "^1.1.0"
 
@@ -4785,14 +4774,7 @@ react-html-attributes@^1.3.0:
   dependencies:
     html-element-attributes "^1.0.0"
 
-react-inspector@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/react-inspector/-/react-inspector-2.1.0.tgz#45504d1e13bc4d10707b977c1ca11484d14616c7"
-  dependencies:
-    babel-runtime "^6.23.0"
-    is-dom "^1.0.9"
-
-react-inspector@^2.1.1:
+react-inspector@^2.0.0, react-inspector@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/react-inspector/-/react-inspector-2.1.1.tgz#2e68030d7ef0811a012f167258dd84232fd5ead1"
   dependencies:


### PR DESCRIPTION
> Fixes #2 

Following the question in #2, here is are some simple modifications that are backward compatibles and add the ability to specify a root value & the context in the config & use them in the mock functions 🌮 