### PR TITLE
Fix peer dependency warnings

### DIFF
--- a/packages/apollo-storybook-core/package.json
+++ b/packages/apollo-storybook-core/package.json
@@ -28,10 +28,10 @@
     "lint"
   ],
   "peerDependencies": {
-    "apollo-cache-inmemory": "1.2.2",
-    "apollo-client": "2.3.2",
-    "apollo-link": "1.2.2",
-    "graphql": "0.13.2",
-    "graphql-tools": "3.0.2"
+    "apollo-cache-inmemory": "^1.2.2",
+    "apollo-client": "^2.3.2",
+    "apollo-link": "^1.2.2",
+    "graphql": "^0.13.2",
+    "graphql-tools": "^3.0.2"
   }
 }

--- a/packages/apollo-storybook-react/package.json
+++ b/packages/apollo-storybook-react/package.json
@@ -28,15 +28,15 @@
     "lint"
   ],
   "peerDependencies": {
-    "apollo-cache-inmemory": "1.2.2",
-    "apollo-client": "2.3.2",
-    "apollo-link": "1.2.2",
-    "graphql": "0.13.2",
-    "graphql-tag": "2.9.2",
-    "graphql-tools": "3.0.2",
-    "react": "16.4.0",
-    "react-apollo": "2.1.4",
-    "react-dom": "16.4.0"
+    "apollo-cache-inmemory": "^1.2.2",
+    "apollo-client": "^2.3.2",
+    "apollo-link": "^1.2.2",
+    "graphql": "^0.13.2",
+    "graphql-tag": "^2.9.2",
+    "graphql-tools": "^3.0.2",
+    "react": "^16.4.0",
+    "react-apollo": "^2.1.4",
+    "react-dom": "^16.4.0"
   },
   "dependencies": {
     "apollo-storybook-core": "^0.3.4"


### PR DESCRIPTION
Currently, users of `apollo-storybook-react` get peer dependency
warnings even if they are already using versions of the peer
dependencies that implement the required APIs.

This change updates the peer dependency specifications to get rid of
these warnings.

Note that the `apollo-storybook-core` dependency in `apollo-storybook-react` will need to be updated once `apollo-storybook-core` is released with a new version number.