### PR TITLE
Accept custom resolver validation options in decorators

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,23 @@ type DecoratorType = {
   context?: Object,
   // optional root value
   rootValue?: Object,
+  // optional resolver validation options, see: https://git.io/fALf4
+  resolverValidationOptions?: Object
 };
+```
+
+##### resolverValidationOptions
+This option gets passed directly to `makeExecutableSchema` of `graphql-tools`, as described at https://git.io/fALf4. This allows you to override `requireResolversForResolveType` and other validation flags:
+```js
+storiesOf('Apollo Client', module).addDecorator(
+  apolloStorybookDecorator({
+    typeDefs,
+    mocks,
+    resolverValidationOptions: {
+      requireResolversForResolveType: false,
+    },
+  })
+);
 ```
 
 ### Development

--- a/packages/apollo-storybook-core/src/index.js
+++ b/packages/apollo-storybook-core/src/index.js
@@ -53,11 +53,12 @@ export default function createClient({
   cacheOptions,
   apolloClientOptions,
   apolloLinkOptions,
+  resolverValidationOptions,
   links = () => {
     return [];
   },
 }) {
-  const schema = makeExecutableSchema({ typeDefs });
+  const schema = makeExecutableSchema({ typeDefs, resolverValidationOptions });
 
   let mockOptions = {};
 

--- a/packages/apollo-storybook-react-native/src/index.js
+++ b/packages/apollo-storybook-react-native/src/index.js
@@ -14,6 +14,7 @@ export default function initializeApollo({
   // cacheOptions is a necessary config parameter because some use cases will require a pre-configured
   // fragmentMatcher such as IntrospectionFragmentMatcher, etc.
   cacheOptions = {},
+  resolverValidationOptions,
 }) {
 
   const graphqlClient = createClient({
@@ -25,6 +26,7 @@ export default function initializeApollo({
     rootValue,
     context,
     cacheOptions,
+    resolverValidationOptions,
   });
 
   function StorybookProvider({ children }) {

--- a/packages/apollo-storybook-react/src/index.js
+++ b/packages/apollo-storybook-react/src/index.js
@@ -14,6 +14,7 @@ export default function initializeApollo({
   // cacheOptions is a necessary config parameter because some use cases will require a pre-configured
   // fragmentMatcher such as IntrospectionFragmentMatcher, etc.
   cacheOptions = {},
+  resolverValidationOptions,
 }) {
   const graphqlClient = createClient({
     mocks,
@@ -25,6 +26,7 @@ export default function initializeApollo({
     context,
     links,
     cacheOptions,
+    resolverValidationOptions,
   });
 
   function StorybookProvider({ children }) {


### PR DESCRIPTION
Hey Abhi, first thanks for the great work!

My MR introduces the possibility for users to set custom `resolverValidationOptions`, as described at https://github.com/apollographql/graphql-tools/blob/master/docs/source/generate-schema.md#makeexecutableschemaoptions.

Thanks for looking into it, looking forward to a feedback.

Remo

