### PR TITLE
resolverValidationOptions-for-vue

### DIFF
--- a/packages/apollo-storybook-vue/src/index.js
+++ b/packages/apollo-storybook-vue/src/index.js
@@ -12,6 +12,7 @@ export default function initializeApollo({
   // cacheOptions is a necessary config parameter because some use cases will require a pre-configured
   // fragmentMatcher such as IntrospectionFragmentMatcher, etc.
   cacheOptions = {},
+  resolverValidationOptions,
   links,
   Vue,
 }) {
@@ -24,6 +25,7 @@ export default function initializeApollo({
     rootValue,
     context,
     cacheOptions,
+    resolverValidationOptions,
     links,
   });
 


### PR DESCRIPTION
In order to pass resolverValidationOptions to apollo-storybook-core's createClient method, we need to accept the argument in the first place. This already worked for React, but not for Vue.