### PR TITLE
Be more tolerant of peer dependencies

### DIFF
--- a/packages/apollo-storybook-core/package.json
+++ b/packages/apollo-storybook-core/package.json
@@ -30,7 +30,8 @@
     "apollo-cache-inmemory": "^1.2.2",
     "apollo-client": "^2.3.2",
     "apollo-link": "^1.2.2",
-    "graphql": "^0.13.2",
-    "graphql-tools": "^3.0.2"
+    "graphql": "^0.11.3 || ^0.12.3 || ^0.13.0 || ^14.0.0",
+    "graphql-tools": "^3.0.2 || ^4.0.0"
   }
 }
+

--- a/packages/apollo-storybook-react/package.json
+++ b/packages/apollo-storybook-react/package.json
@@ -33,11 +33,11 @@
     "apollo-cache-inmemory": "^1.2.2",
     "apollo-client": "^2.3.2",
     "apollo-link": "^1.2.2",
-    "graphql": "^0.13.2",
+    "graphql": "^0.11.3 || ^0.12.3 || ^0.13.0 || ^14.0.0",
     "graphql-tag": "^2.9.2",
-    "graphql-tools": "^3.0.2",
+    "graphql-tools": "^3.0.2 || ^4.0.0",
     "react": "^16.4.0",
-    "react-apollo": "^2.1.4",
+    "react-apollo": "^2.1.4 || ^3.0.0",
     "react-dom": "^16.4.0"
   },
   "dependencies": {


### PR DESCRIPTION
Hi @abhiaiyer91 thx for your great work.
I am experiencing a few yarn warnings after installing your module:
```
apollo-storybook-react@0.2.1" has incorrect peer dependency "graphql@^0.13.2".
apollo-storybook-react@0.2.1" has incorrect peer dependency "react-apollo@^2.1.4".
apollo-storybook-react > apollo-storybook-core@0.5.2" has incorrect peer dependency "graphql@^0.13.2".
```

Can we be more tolerant here?