### PR TITLE
docs(README): fix link for graphql-tools mocking

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 ## The Gist
 
 - Provide GraphQL type definitions to the decorator.
-- Provide a Mock object like you would with `graphql-tools` http://dev.apollodata.com/tools/graphql-tools/mocking.html
+- Provide a Mock object like you would with `graphql-tools` https://www.graphql-tools.com/docs/mocking/
 
 Take this:
 


### PR DESCRIPTION
The old link no longer works.